### PR TITLE
Update browerify and ngrok dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   "author": "mactkg <mactkg@gmail.com> (http://makerbox.net/)",
   "license": "ISC",
   "devDependencies": {
-    "browserify": "^11.2.0",
+    "browserify": "^13.0.0",
     "gulp": "^3.9.0",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.6",
     "gulp-webserver": "^0.9.1",
-    "ngrok": "^0.2.2",
+    "ngrok": "^2.1.6",
     "vinyl-source-stream": "^1.1.0"
   }
 }


### PR DESCRIPTION
ngrok update fixes error 103 ("failed to start tunnel") on free plans
